### PR TITLE
Add logging test for orchestrator

### DIFF
--- a/src/test_orchestrator.py
+++ b/src/test_orchestrator.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import patch
+import io
 
 from agents import Orchestrator
 
@@ -12,6 +14,17 @@ class TestOrchestrator(unittest.TestCase):
         # Result should be trimmed to 50 chars and stripped
         expected = data.strip()[:50]
         self.assertEqual(result, expected)
+
+    def test_logger_outputs_messages(self):
+        data = "Capture the logs"
+        orchestrator = Orchestrator()
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            orchestrator.run(data)
+            lines = mock_stdout.getvalue().strip().splitlines()
+        self.assertGreaterEqual(len(lines), 3)
+        self.assertEqual(lines[0], "[LOG] Parsing data")
+        self.assertEqual(lines[1], "[LOG] Summarizing data")
+        self.assertEqual(lines[2], "[LOG] Optimizing summary")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- test stdout logging in orchestrator

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=src python -m unittest src.test_orchestrator -v`


------
https://chatgpt.com/codex/tasks/task_e_686efe11b05c83238fcfcf4ad0555a6b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify that log messages are correctly output during the orchestration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->