### PR TITLE
Add docs site and diagrams

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs
+      - run: mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Production-ready** modular MCP agent orchestration system with comprehensive monitoring, security, and scalability features. The orchestrator coordinates DataParser, Summarizer, Optimizer and Logger agents to process input text through a robust pipeline.
 
+Documentation is available in the [docs](docs/index.md) folder and on the project site.
+
 ## 🚀 Production Features
 
 - ✅ **Async Processing** - High-performance concurrent request handling

--- a/diagrams/architecture.mmd
+++ b/diagrams/architecture.mmd
@@ -1,0 +1,8 @@
+graph TD
+    A[Client Request] --> B[FastAPI Server]
+    B --> C[Orchestrator]
+    C --> D[DataParserAgent]
+    C --> E[SummarizerAgent]
+    C --> F[OptimizerAgent]
+    C --> G[LoggerAgent]
+    C --> H[Monitoring]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,14 @@
+# Architecture
+
+```mermaid
+graph TD
+    A[Client Request] --> B[FastAPI Server]
+    B --> C[Orchestrator]
+    C --> D[DataParserAgent]
+    C --> E[SummarizerAgent]
+    C --> F[OptimizerAgent]
+    C --> G[LoggerAgent]
+    C --> H[Monitoring]
+```
+
+This diagram illustrates the high level flow of a request through the MCP Agent Stack.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# MCP Agent Stack Documentation
+
+Welcome to the documentation site for the **MCP Agent Stack**. This site provides an overview of the system, how to run it, and details about its architecture.
+
+- [Architecture](architecture.md)
+- [Deployment](../DEPLOYMENT.md)
+- [Production Ready Summary](../PRODUCTION_READY_SUMMARY.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: MCP Agent Stack
+nav:
+  - Home: docs/index.md
+  - Architecture: docs/architecture.md
+  - Deployment: DEPLOYMENT.md
+  - Production Ready Summary: PRODUCTION_READY_SUMMARY.md
+markdown_extensions:
+  - admonition
+  - codehilite
+  - toc

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: MCP Agent Stack
 nav:
-  - Home: docs/index.md
-  - Architecture: docs/architecture.md
+  - Home: index.md
+  - Architecture: architecture.md
   - Deployment: DEPLOYMENT.md
   - Production Ready Summary: PRODUCTION_READY_SUMMARY.md
 markdown_extensions:


### PR DESCRIPTION
## Summary
- document how to access the docs
- add MkDocs site
- include architecture diagram
- deploy docs with GitHub Actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688cf9debfdc8323a13b5d52a0da3e63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a documentation site for the MCP Agent Stack, including an architecture overview, deployment guide, and production readiness summary.
  * Added a visual architecture diagram to help users understand system interactions.

* **Documentation**
  * Updated the README to reference the new documentation resources.
  * Added detailed architecture documentation and a site index with navigation links.
  * Included a configuration file to enhance documentation presentation and usability.

* **Chores**
  * Set up automated deployment of documentation to GitHub Pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->